### PR TITLE
Add an argument for user-specified header fields

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -13,24 +13,25 @@ api_url <- "https://api.github.com"
 
 ## Headers to send with each API request
 
-send_headers <- c("accept" = "application/vnd.github.v3+json",
-                  "user-agent" = "https://github.com/gaborcsardi/whoami")
+send_headers <- c("Accept" = "application/vnd.github.v3+json",
+                  "User-Agent" = "https://github.com/gaborcsardi/whoami")
 
 #' Query the GitHub API
 #'
 #' This is an extremely minimal client. You need to know the API
 #' to be able to use this client. All this function does is
 #' \itemize{
-#'   \item Tries to substitute each listed parameter into
+#'   \item Try to substitute each listed parameter into
 #'     \code{endpoint}, using the \code{:parameter} notation.
-#'   \item If a GET request (the default), then adds
+#'   \item If a GET request (the default), then add
 #'     all other listed parameters as query parameters.
-#'   \item If not a GET request, then sends the other parameters
+#'   \item If not a GET request, then send the other parameters
 #'     in the request body, as JSON.
-#'   \item Converts the response to an R list using
-#'     \code{jsonline::fromJSON}.
+#'   \item Convert the response to an R list using
+#'     \code{jsonlite::fromJSON}.
 #' }
 #'
+
 #' @param endpoint GitHub API endpoint. See examples below.
 #' @param ... Additional parameters
 #' @param .token Authentication token.
@@ -42,6 +43,16 @@ send_headers <- c("accept" = "application/vnd.github.v3+json",
 #'   Note, that if you request many records, then multiple GitHub
 #'   API calls are used to get them, and this can take a potentially
 #'   long time.
+#' @param .send_headers Named character vector of header field values
+#'   (excepting \code{Authorization}, which is handled via
+#'   \code{.token}). This can be used to override or augment the
+#'   defaults, which are as follows: the \code{Accept} field defaults
+#'   to \code{"application/vnd.github.v3+json"} and the
+#'   \code{User-Agent} field defaults to
+#'   \code{"https://github.com/gaborcsardi/whoami"}. This can be used
+#'   to, e.g., provide a custom media type, in order to access a
+#'   preview feature of the API.
+#'
 #' @return Answer from the API.
 #'
 #' @importFrom httr content add_headers headers
@@ -65,10 +76,15 @@ send_headers <- c("accept" = "application/vnd.github.v3+json",
 #' ## Automatic pagination
 #' users <- gh("/users", .limit = 50)
 #' length(users)
+#'
+#' ## Access developer preview of Licenses API (in preview on 2015-09-20)
+#' gh("/licenses") # error code 415
+#' gh("/licenses",
+#'    .send_headers = c("Accept" = "application/vnd.github.drax-preview+json"))
 #' }
 
 gh <- function(endpoint, ..., .token = Sys.getenv('GITHUB_TOKEN'),
-               .limit = NULL) {
+               .limit = NULL, .send_headers = NULL) {
 
   params <- list(...)
 
@@ -78,10 +94,11 @@ gh <- function(endpoint, ..., .token = Sys.getenv('GITHUB_TOKEN'),
   params <- parsed$params
 
   auth <- get_auth(.token)
+  headers <- get_headers(.send_headers)
 
   url <- paste0(api_url, endpoint)
 
-  res <- gh_url(method, url, auth, params)
+  res <- gh_url(method, url, auth, headers, params)
 
   while (! is.null(.limit) && length(res) < .limit && gh_has_next(res)) {
     res2 <- gh_next(res, .token = .token)
@@ -100,8 +117,19 @@ get_auth <- function(token) {
   auth
 }
 
+get_headers <- function(headers = NULL) {
 
-gh_url <- function(method, url, auth, params) {
+  if (is.null(headers))
+    send_headers
+  else
+    c(headers,
+      send_headers[ ! tolower(names(send_headers)) %in%
+                      tolower(names(headers))])
+
+}
+
+
+gh_url <- function(method, url, auth, headers, params) {
 
   method_fun <- list("GET" = GET, "POST" = POST, "PATCH" = PATCH,
                      "PUT" = PUT, "DELETE" = DELETE)[[method]]
@@ -114,18 +142,18 @@ gh_url <- function(method, url, auth, params) {
   if (method == "GET" && length(params) > 0) {
     response <- GET(
       url = url,
-      add_headers(.headers = c(send_headers, auth)),
+      add_headers(.headers = c(headers, auth)),
       query = params
     )
   } else if (method == "GET") {
     response <- GET(
       url = url,
-      add_headers(.headers = c(send_headers, auth))
+      add_headers(.headers = c(headers, auth))
     )
   } else {
     response <- method_fun(
       url = url,
-      add_headers(.headers = c(send_headers, auth)),
+      add_headers(.headers = c(headers, auth)),
       body = toJSON(params, auto_unbox = TRUE)
     )
   }

--- a/R/package.R
+++ b/R/package.R
@@ -101,7 +101,7 @@ gh <- function(endpoint, ..., .token = Sys.getenv('GITHUB_TOKEN'),
   res <- gh_url(method, url, auth, headers, params)
 
   while (! is.null(.limit) && length(res) < .limit && gh_has_next(res)) {
-    res2 <- gh_next(res, .token = .token)
+    res2 <- gh_next(res, .token = .token, headers)
     res3 <- c(res, res2)
     attributes(res3) <- attributes(res2)
     res <- res3

--- a/R/package.R
+++ b/R/package.R
@@ -171,7 +171,7 @@ gh_url <- function(method, url, auth, headers, params) {
     cond <- structure(list(
       content = res,
       headers = heads,
-      message = "GitHub API error"
+      message = paste("GitHub API error", heads$`status`)
     ), class = "condition")
     stop(cond)
   }

--- a/R/pagination.R
+++ b/R/pagination.R
@@ -29,7 +29,7 @@ gh_has_next <- function(gh_response) {
   gh_has(gh_response, "next")
 }
 
-gh_link <- function(gh_response, .token, link) {
+gh_link <- function(gh_response, .token, .send_headers, link) {
 
   stopifnot(is(gh_response, "gh_response"))
 
@@ -40,6 +40,7 @@ gh_link <- function(gh_response, .token, link) {
     method = attr(gh_response, "method"),
     url = url,
     auth = get_auth(.token),
+    headers = get_headers(.send_headers),
     params = list()
   )
 
@@ -56,7 +57,7 @@ gh_link <- function(gh_response, .token, link) {
 #' If the requested page does not exist, an error is thrown.
 #'
 #' @param gh_response An object returned by a \code{gh()} call.
-#' @param .token Authentication token.
+#' @inheritParams gh
 #' @return Answer from the API.
 #'
 #' @name gh_next
@@ -69,30 +70,34 @@ gh_link <- function(gh_response, .token, link) {
 #' sapply(x2, "[[", "login")
 #' }
 
-gh_next <- function(gh_response, .token = Sys.getenv("GITHUB_TOKEN")) {
-  gh_link(gh_response, .token, "next")
+gh_next <- function(gh_response, .token = Sys.getenv("GITHUB_TOKEN"),
+                    .send_headers = NULL) {
+  gh_link(gh_response, .token, .send_headers, "next")
 }
 
 
 #' @name gh_next
 #' @export
 
-gh_prev <- function(gh_response, .token = Sys.getenv("GITHUB_TOKEN")) {
-  gh_link(gh_response, .token, "prev")
+gh_prev <- function(gh_response, .token = Sys.getenv("GITHUB_TOKEN"),
+                    .send_headers = NULL) {
+  gh_link(gh_response, .token, .send_headers, "prev")
 }
 
 
 #' @name gh_next
 #' @export
 
-gh_first <- function(gh_response, .token = Sys.getenv("GITHUB_TOKEN")) {
-  gh_link(gh_response, .token, "first")
+gh_first <- function(gh_response, .token = Sys.getenv("GITHUB_TOKEN"),
+                     .send_headers = NULL) {
+  gh_link(gh_response, .token, .send_headers, "first")
 }
 
 
 #' @name gh_next
 #' @export
 
-gh_last <- function(gh_response, .token = Sys.getenv("GITHUB_TOKEN")) {
-  gh_link(gh_response, .token, "last")
+gh_last <- function(gh_response, .token = Sys.getenv("GITHUB_TOKEN"),
+                    .send_headers = NULL) {
+  gh_link(gh_response, .token, .send_headers, "last")
 }

--- a/man/gh.Rd
+++ b/man/gh.Rd
@@ -6,7 +6,8 @@
 \alias{gh-package}
 \title{GitHub API}
 \usage{
-gh(endpoint, ..., .token = Sys.getenv("GITHUB_TOKEN"), .limit = NULL)
+gh(endpoint, ..., .token = Sys.getenv("GITHUB_TOKEN"), .limit = NULL,
+  .send_headers = NULL)
 }
 \arguments{
 \item{endpoint}{GitHub API endpoint. See examples below.}
@@ -23,6 +24,16 @@ records, and also to \code{Inf} to request all records.
 Note, that if you request many records, then multiple GitHub
 API calls are used to get them, and this can take a potentially
 long time.}
+
+\item{.send_headers}{Named character vector of header field values
+  (excepting \code{Authorization}, which is handled via
+  \code{.token}). This can be used to override or augment the
+  defaults, which are as follows: the \code{Accept} field defaults
+  to \code{"application/vnd.github.v3+json"} and the
+  \code{User-Agent} field defaults to
+  \code{"https://github.com/gaborcsardi/whoami"}. This can be used
+  to, e.g., provide a custom media type, in order to access a
+  preview feature of the API.}
 }
 \value{
 Answer from the API.
@@ -33,14 +44,14 @@ Minimal wrapper to access GitHub's API.
 This is an extremely minimal client. You need to know the API
 to be able to use this client. All this function does is
 \itemize{
-  \item Tries to substitute each listed parameter into
+  \item Try to substitute each listed parameter into
     \code{endpoint}, using the \code{:parameter} notation.
-  \item If a GET request (the default), then adds
+  \item If a GET request (the default), then add
     all other listed parameters as query parameters.
-  \item If not a GET request, then sends the other parameters
+  \item If not a GET request, then send the other parameters
     in the request body, as JSON.
-  \item Converts the response to an R list using
-    \code{jsonline::fromJSON}.
+  \item Convert the response to an R list using
+    \code{jsonlite::fromJSON}.
 }
 }
 \examples{
@@ -60,6 +71,11 @@ gh("/repos/:owner/:repo/issues", owner = "hadley", repo = "dplyr")
 ## Automatic pagination
 users <- gh("/users", .limit = 50)
 length(users)
+
+## Access developer preview of Licenses API (in preview on 2015-09-20)
+gh("/licenses") # error code 415
+gh("/licenses",
+   .send_headers = c("Accept" = "application/vnd.github.drax-preview+json"))
 }
 }
 

--- a/man/gh_next.Rd
+++ b/man/gh_next.Rd
@@ -7,18 +7,32 @@
 \alias{gh_prev}
 \title{Get the next, previous, first or last page of results}
 \usage{
-gh_next(gh_response, .token = Sys.getenv("GITHUB_TOKEN"))
+gh_next(gh_response, .token = Sys.getenv("GITHUB_TOKEN"),
+  .send_headers = NULL)
 
-gh_prev(gh_response, .token = Sys.getenv("GITHUB_TOKEN"))
+gh_prev(gh_response, .token = Sys.getenv("GITHUB_TOKEN"),
+  .send_headers = NULL)
 
-gh_first(gh_response, .token = Sys.getenv("GITHUB_TOKEN"))
+gh_first(gh_response, .token = Sys.getenv("GITHUB_TOKEN"),
+  .send_headers = NULL)
 
-gh_last(gh_response, .token = Sys.getenv("GITHUB_TOKEN"))
+gh_last(gh_response, .token = Sys.getenv("GITHUB_TOKEN"),
+  .send_headers = NULL)
 }
 \arguments{
 \item{gh_response}{An object returned by a \code{gh()} call.}
 
 \item{.token}{Authentication token.}
+
+\item{.send_headers}{Named character vector of header field values
+  (excepting \code{Authorization}, which is handled via
+  \code{.token}). This can be used to override or augment the
+  defaults, which are as follows: the \code{Accept} field defaults
+  to \code{"application/vnd.github.v3+json"} and the
+  \code{User-Agent} field defaults to
+  \code{"https://github.com/gaborcsardi/whoami"}. This can be used
+  to, e.g., provide a custom media type, in order to access a
+  preview feature of the API.}
 }
 \value{
 Answer from the API.


### PR DESCRIPTION
New features of the API generally require a custom media type during the preview period. See for example the new [Licenses API](https://developer.github.com/v3/licenses/). The new `.send_headers` argument allows user to provide additional header fields or to override defaults.

BTW I made the error message a bit more informative.

I also changed the capitalization of `Accept` and `User-Agent`. I know header field names aren't *supposed* to be case sensitive and yet, when specifying custom media type, I have seen sometimes they are? The first error here is expected because the custom media type is incorrectly specified in the default headers. But the second error seems to come from specificying the `"accept"` field instead of "`Accept`". The third call demonstrates what this PR is adding.

``` r
gh("/licenses")
 Error: GitHub API error 415 Unsupported Media Type
gh("/licenses",
   .send_headers = c("accept" = "application/vnd.github.drax-preview+json"))
 Error: GitHub API error 415 Unsupported Media Type
gh("/licenses",
   .send_headers = c("Accept" = "application/vnd.github.drax-preview+json"))
#> [
#>   {
#>     "key": "gpl-2.0",
#>     "name": "GNU General Public License v2.0",
#>     "url": "https://api.github.com/licenses/gpl-2.0",
#>     "featured": true
#>   },
#>   {
#>     "key": "mit",
#>     "name": "MIT License",
#>     "url": "https://api.github.com/licenses/mit",
#>     "featured": true
#>   },
#>   AND SO ON AND SO FORTH
#> ]
```

I guess that's GitHub problem? ¯\_(ツ)_/¯. Anyway, it inspired me to switch the default names to the most common casing.


