### PR TITLE
Add call and error class to the cond when status code >= 300

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -141,10 +141,11 @@ gh_url <- function(method, url, auth, params) {
 
   if (status_code(response) >= 300) {
     cond <- structure(list(
+      call = sys.call(-1),
       content = res,
       headers = heads,
-      message = "GitHub API error"
-    ), class = "condition")
+      message = paste("GitHub API error", heads$`status`)
+    ), class = c("condition", "error"))
     stop(cond)
   }
 


### PR DESCRIPTION
This allows a loop to continue after error and to return the error itself. Fixes #12.

``` r
library(gh)
foo <- function(endpoints) {
  lapply(endpoints, function(x) try(gh(x)))
}

## /licenses endpoint will not work w/o custom media type
res <- foo(c("/emojis", "/licenses", "/gitignore/templates"))
## error successfully caught

str(res, max.level = 1)
#> List of 3
#>  $ :List of 888
#>   .. [list output truncated]
#>   ..- attr(*, "method")= chr "GET"
#>   ..- attr(*, "response")=List of 26
#>   .. ..- attr(*, "class")= chr [1:2] "insensitive" "list"
#>   ..- attr(*, "class")= chr "gh_response"
#>  $ :Class 'try-error'  atomic [1:1] Error in gh(x) : GitHub API error 415 Unsupported Media Type
#> 
#>   .. ..- attr(*, "condition")=List of 4
#>   .. .. ..- attr(*, "class")= chr [1:2] "condition" "error"
#>  $ :List of 120
#>   .. [list output truncated]
#>   ..- attr(*, "method")= chr "GET"
#>   ..- attr(*, "response")=List of 26
#>   .. ..- attr(*, "class")= chr [1:2] "insensitive" "list"
#>   ..- attr(*, "class")= chr "gh_response"
```