### PR TITLE
Add an argument for user-specified header fields

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -178,6 +178,7 @@ gh_url <- function(method, url, auth, headers, params) {
 
   attr(res, "method") <- method
   attr(res, "response") <- headers(response)
+  attr(res, ".send_headers") <- headers
   class(res) <- "gh_response"
   res
 }

--- a/R/package.R
+++ b/R/package.R
@@ -13,24 +13,25 @@ api_url <- "https://api.github.com"
 
 ## Headers to send with each API request
 
-send_headers <- c("accept" = "application/vnd.github.v3+json",
-                  "user-agent" = "https://github.com/gaborcsardi/whoami")
+send_headers <- c("Accept" = "application/vnd.github.v3+json",
+                  "User-Agent" = "https://github.com/gaborcsardi/whoami")
 
 #' Query the GitHub API
 #'
 #' This is an extremely minimal client. You need to know the API
 #' to be able to use this client. All this function does is
 #' \itemize{
-#'   \item Tries to substitute each listed parameter into
+#'   \item Try to substitute each listed parameter into
 #'     \code{endpoint}, using the \code{:parameter} notation.
-#'   \item If a GET request (the default), then adds
+#'   \item If a GET request (the default), then add
 #'     all other listed parameters as query parameters.
-#'   \item If not a GET request, then sends the other parameters
+#'   \item If not a GET request, then send the other parameters
 #'     in the request body, as JSON.
-#'   \item Converts the response to an R list using
-#'     \code{jsonline::fromJSON}.
+#'   \item Convert the response to an R list using
+#'     \code{jsonlite::fromJSON}.
 #' }
 #'
+
 #' @param endpoint GitHub API endpoint. See examples below.
 #' @param ... Additional parameters
 #' @param .token Authentication token.
@@ -42,6 +43,16 @@ send_headers <- c("accept" = "application/vnd.github.v3+json",
 #'   Note, that if you request many records, then multiple GitHub
 #'   API calls are used to get them, and this can take a potentially
 #'   long time.
+#' @param .send_headers Named character vector of header field values
+#'   (excepting \code{Authorization}, which is handled via
+#'   \code{.token}). This can be used to override or augment the
+#'   defaults, which are as follows: the \code{Accept} field defaults
+#'   to \code{"application/vnd.github.v3+json"} and the
+#'   \code{User-Agent} field defaults to
+#'   \code{"https://github.com/gaborcsardi/whoami"}. This can be used
+#'   to, e.g., provide a custom media type, in order to access a
+#'   preview feature of the API.
+#'
 #' @return Answer from the API.
 #'
 #' @importFrom httr content add_headers headers
@@ -65,10 +76,15 @@ send_headers <- c("accept" = "application/vnd.github.v3+json",
 #' ## Automatic pagination
 #' users <- gh("/users", .limit = 50)
 #' length(users)
+#'
+#' ## Access developer preview of Licenses API (in preview as of 2015-09-24)
+#' gh("/licenses") # error code 415
+#' gh("/licenses",
+#'    .send_headers = c("Accept" = "application/vnd.github.drax-preview+json"))
 #' }
 
 gh <- function(endpoint, ..., .token = Sys.getenv('GITHUB_TOKEN'),
-               .limit = NULL) {
+               .limit = NULL, .send_headers = NULL) {
 
   params <- list(...)
 
@@ -78,10 +94,11 @@ gh <- function(endpoint, ..., .token = Sys.getenv('GITHUB_TOKEN'),
   params <- parsed$params
 
   auth <- get_auth(.token)
+  headers <- get_headers(.send_headers)
 
   url <- paste0(api_url, endpoint)
 
-  res <- gh_url(method, url, auth, params)
+  res <- gh_url(method, url, auth, headers, params)
 
   while (! is.null(.limit) && length(res) < .limit && gh_has_next(res)) {
     res2 <- gh_next(res, .token = .token)
@@ -100,8 +117,19 @@ get_auth <- function(token) {
   auth
 }
 
+get_headers <- function(headers = NULL) {
 
-gh_url <- function(method, url, auth, params) {
+  if (is.null(headers))
+    send_headers
+  else
+    c(headers,
+      send_headers[ ! tolower(names(send_headers)) %in%
+                      tolower(names(headers))])
+
+}
+
+
+gh_url <- function(method, url, auth, headers, params) {
 
   method_fun <- list("GET" = GET, "POST" = POST, "PATCH" = PATCH,
                      "PUT" = PUT, "DELETE" = DELETE)[[method]]
@@ -114,18 +142,18 @@ gh_url <- function(method, url, auth, params) {
   if (method == "GET" && length(params) > 0) {
     response <- GET(
       url = url,
-      add_headers(.headers = c(send_headers, auth)),
+      add_headers(.headers = c(headers, auth)),
       query = params
     )
   } else if (method == "GET") {
     response <- GET(
       url = url,
-      add_headers(.headers = c(send_headers, auth))
+      add_headers(.headers = c(headers, auth))
     )
   } else {
     response <- method_fun(
       url = url,
-      add_headers(.headers = c(send_headers, auth)),
+      add_headers(.headers = c(headers, auth)),
       body = toJSON(params, auto_unbox = TRUE)
     )
   }
@@ -143,7 +171,7 @@ gh_url <- function(method, url, auth, params) {
     cond <- structure(list(
       content = res,
       headers = heads,
-      message = "GitHub API error"
+      message = paste("GitHub API error", heads$`status`)
     ), class = "condition")
     stop(cond)
   }

--- a/R/pagination.R
+++ b/R/pagination.R
@@ -40,6 +40,7 @@ gh_link <- function(gh_response, .token, link) {
     method = attr(gh_response, "method"),
     url = url,
     auth = get_auth(.token),
+    headers = attr(gh_response, ".send_headers"),
     params = list()
   )
 

--- a/man/gh.Rd
+++ b/man/gh.Rd
@@ -6,7 +6,8 @@
 \alias{gh-package}
 \title{GitHub API}
 \usage{
-gh(endpoint, ..., .token = Sys.getenv("GITHUB_TOKEN"), .limit = NULL)
+gh(endpoint, ..., .token = Sys.getenv("GITHUB_TOKEN"), .limit = NULL,
+  .send_headers = NULL)
 }
 \arguments{
 \item{endpoint}{GitHub API endpoint. See examples below.}
@@ -23,6 +24,16 @@ records, and also to \code{Inf} to request all records.
 Note, that if you request many records, then multiple GitHub
 API calls are used to get them, and this can take a potentially
 long time.}
+
+\item{.send_headers}{Named character vector of header field values
+  (excepting \code{Authorization}, which is handled via
+  \code{.token}). This can be used to override or augment the
+  defaults, which are as follows: the \code{Accept} field defaults
+  to \code{"application/vnd.github.v3+json"} and the
+  \code{User-Agent} field defaults to
+  \code{"https://github.com/gaborcsardi/whoami"}. This can be used
+  to, e.g., provide a custom media type, in order to access a
+  preview feature of the API.}
 }
 \value{
 Answer from the API.
@@ -33,14 +44,14 @@ Minimal wrapper to access GitHub's API.
 This is an extremely minimal client. You need to know the API
 to be able to use this client. All this function does is
 \itemize{
-  \item Tries to substitute each listed parameter into
+  \item Try to substitute each listed parameter into
     \code{endpoint}, using the \code{:parameter} notation.
-  \item If a GET request (the default), then adds
+  \item If a GET request (the default), then add
     all other listed parameters as query parameters.
-  \item If not a GET request, then sends the other parameters
+  \item If not a GET request, then send the other parameters
     in the request body, as JSON.
-  \item Converts the response to an R list using
-    \code{jsonline::fromJSON}.
+  \item Convert the response to an R list using
+    \code{jsonlite::fromJSON}.
 }
 }
 \examples{
@@ -60,6 +71,11 @@ gh("/repos/:owner/:repo/issues", owner = "hadley", repo = "dplyr")
 ## Automatic pagination
 users <- gh("/users", .limit = 50)
 length(users)
+
+## Access developer preview of Licenses API (in preview on 2015-09-20)
+gh("/licenses") # error code 415
+gh("/licenses",
+   .send_headers = c("Accept" = "application/vnd.github.drax-preview+json"))
 }
 }
 

--- a/man/gh.Rd
+++ b/man/gh.Rd
@@ -72,7 +72,7 @@ gh("/repos/:owner/:repo/issues", owner = "hadley", repo = "dplyr")
 users <- gh("/users", .limit = 50)
 length(users)
 
-## Access developer preview of Licenses API (in preview on 2015-09-20)
+## Access developer preview of Licenses API (in preview as of 2015-09-24)
 gh("/licenses") # error code 415
 gh("/licenses",
    .send_headers = c("Accept" = "application/vnd.github.drax-preview+json"))


### PR DESCRIPTION
New features of the API generally require a custom media type during the preview period. See for example the new [Licenses API](https://developer.github.com/v3/licenses/). The new `.send_headers` argument allows user to provide additional header fields or to override defaults.

I also changed the capitalization of `Accept` and `User-Agent`. I know header field names aren't *supposed* to be case sensitive and yet, when specifying custom media type, I have seen sometimes they are? The first error here is expected because the custom media type is incorrectly specified in the default headers. But the second error seems to come from specificying the `"accept"` field instead of "`Accept`". The third call demonstrates what this PR is adding. The fourth and fifth show that custom headers are used during page traversal.

``` r
gh("/licenses")
#> condition in gh("/licenses"): GitHub API error 415 Unsupported Media Type

## "accept" does not seem to work?!?
gh("/licenses",
   .send_headers = c("accept" = "application/vnd.github.drax-preview+json"))
#> condition in gh("/licenses", .send_headers = c(accept = "application/vnd.github.drax-preview+json")): GitHub API error 415 Unsupported Media Type

## but "Accept" does
gh("/licenses",
   .send_headers = c("Accept" = "application/vnd.github.drax-preview+json"))
#> [
#>   {
#>     "key": "gpl-3.0",
#>     "name": "GNU General Public License v3.0",
#>     "url": "https://api.github.com/licenses/gpl-3.0",
#>     "featured": false
#>   },
#>  AND SO ON AND SO FORTH
#> ]

## custom headers also work with pagination
two_pages <- gh("/licenses", per_page = 3, .limit = 6,
                .send_headers = c(
                  "Accept" = "application/vnd.github.drax-preview+json"))
str(two_pages, max.level = 1, give.attr = FALSE)
#> List of 6
#>  $ :List of 4
#>  $ :List of 4
#>  $ :List of 4
#>  $ :List of 4
#>  $ :List of 4
#>  $ :List of 4

third_page <- gh_next(two_pages)
str(third_page, max.level = 1, give.attr = FALSE)
#> List of 3
#>  $ :List of 4
#>  $ :List of 4
#>  $ :List of 4
```