### PR TITLE
attempt endpoint parameter substitution with exactly 1 item

### DIFF
--- a/R/parse_end_point.R
+++ b/R/parse_end_point.R
@@ -6,7 +6,7 @@ parse_endpoint <- function(endpoint, params) {
   done <- logical(length(params))
   for (i in seq_along(params)) {
     n <- names(params)[i]
-    p <- params[[i]]
+    p <- params[[i]][1]
     endpoint2 <- gsub(paste0(":", n, "\\b"), p, endpoint)
     if (endpoint2 != endpoint) {
       endpoint <- endpoint2


### PR DESCRIPTION
Silences a warning that occurs whenever user supplies input that has length greater than one. This sort of input is ultimately destined to become a query parameter and not substituted into the endpoint URL. I don't think this needs to be documented (?).

Example: the `labels` one can provide when opening an issue.

``` r
library(gh)

retval <- gh("POST /repos/:owner/:repo/issues",
             owner = "STAT545-UBC", repo = "test-repo",
             title = "hw04 peer review", body = "review your peer's work",
             assignee = "jennybc", labels = c("peer-review", "hw04"))
#> Warning in gsub(paste0(":", n, "\\b"), p, endpoint): argument 'replacement'
#> has length > 1 and only the first element will be used
```
