### PR TITLE
reveal error message

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -175,7 +175,7 @@ gh_url <- function(method, url, auth, headers, params) {
       call = sys.call(-1),
       content = res,
       headers = heads,
-      message = paste("GitHub API error", heads$`status`)
+      message = paste0("GitHub API error: ", heads$`status`, "\n  ", res$message, "\n")
     ), class = c("condition", "error"))
     stop(cond)
   }


### PR DESCRIPTION
I make a lot of bulk requests and get all sorts of errors. It's easier for me to troubleshoot if the error message is exposed. PR causes inclusion of the very informative "Please upgrade your plan to create a new private repository."

``` r
res <- gh("POST /user/repos", name = "borat", private = TRUE)
#> Error in gh("POST /user/repos", name = "borat", private = TRUE) :
#>   GitHub API error: 422 Unprocessable Entity
#>   Please upgrade your plan to create a new private repository.
```