### PR TITLE
retain attributes when .limit is enforced

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -117,7 +117,9 @@ gh <- function(endpoint, ..., .token = NULL,
   }
 
   if (! is.null(.limit) && length(res) > .limit) {
+    res_attr <- attributes(res)
     res <- res[seq_len(.limit)]
+    attributes(res) <- res_attr
   }
 
   res


### PR DESCRIPTION
as per this discussion https://github.com/gaborcsardi/gh/commit/d2f8a7cab5b746c5d4a4599bb4406fd1b272a2e0#commitcomment-15717354

It wasn't just the `gh_response` class that was being lost but all attributes. Is there some more compact way to do this?