### PR TITLE
some API errors result in a non-JSON response

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -186,8 +186,13 @@ gh_url <- function(method, url, auth, headers, params) {
   } else if (grepl("^application/json", heads$`content-type`,
                    ignore.case = TRUE)) {
     res <- fromJSON(content(response, as = "text"), simplifyVector = FALSE)
+  } else if (grepl("^text/html", heads$`content-type`, ignore.case = TRUE)) {
+    x <- tempfile(pattern = "gh-github-api-error-", fileext = ".html")
+    write(res, x)
+    browseURL(x)
+    res <- list(message = "html response :(")
   } else {
-    res <- content(response, as = "text")
+    res <- list(message = content(response, as = "text"))
   }
 
   if (status_code(response) >= 300) {
@@ -195,7 +200,8 @@ gh_url <- function(method, url, auth, headers, params) {
       call = sys.call(-1),
       content = res,
       headers = heads,
-      message = paste0("GitHub API error: ", heads$`status`, "\n  ", res$message, "\n")
+      message = paste0("GitHub API error (", status_code(response), "): ",
+                       heads$`status`, "\n  ", res$message, "\n")
     ), class = c("condition", "error"))
     stop(cond)
   }


### PR DESCRIPTION
This seems a rather weird solution, so feel free to close.

I don't know why the GitHub API would return an error (400) but include the "error message" as html, not JSON. Also not put the status code in the headers. And yet it can happen for an ill-formed endpoint. If I try to get the "help wanted" label (prior to applying PR #36), you get such a mysterious failure. 

This PR gives the user slightly more useful information for troubleshooting:

``` r
gh("/repos/gaborcsardi/gh/labels/:name", name = "help wanted")
#> Error in gh("/repos/gaborcsardi/gh/labels/:name", name = "help wanted") : 
#>   GitHub API error (400):
#>   html response :(
```

and then this shows up in user's browser:

<img width="631" alt="screen shot 2016-09-05 at 4 24 47 pm" src="https://cloud.githubusercontent.com/assets/599454/18258388/5a0cfcd0-7389-11e6-99bf-8c6eb834ef21.png">